### PR TITLE
Verify that given private and public keys match

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.medizininformatik-initiative</groupId>
@@ -75,6 +75,13 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.27.6</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -314,3 +321,4 @@
 		</plugins>
 	</reporting>
 </project>
+

--- a/src/main/java/de/medizininformatik_initiative/processes/common/crypto/KeyProviderImpl.java
+++ b/src/main/java/de/medizininformatik_initiative/processes/common/crypto/KeyProviderImpl.java
@@ -12,6 +12,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
@@ -47,8 +49,25 @@ public class KeyProviderImpl implements KeyProvider, InitializingBean
 	// openssl rsa -in keypair.pem -pubout -out publickey.crt
 	// openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in keypair.pem -out pkcs8.key
 
+
 	/**
-	 * One or both parameters should be <code>null</code>
+	 * Creating a KeyProviderImpl without private and public keys, e.g. if only {@link #readPublicKeyIfExists(String)}
+	 * is used. The method {@link #createPublicKeyIfNotExists()} will not do anything in this case.
+	 *
+	 * @param api
+	 *            not <code>null</code>
+	 * @param dataLogger
+	 *            not <code>null</code>
+	 * @return KeyProvider
+	 */
+	public static KeyProviderImpl fromNoKeys(ProcessPluginApi api, DataLogger dataLogger)
+	{
+		return new KeyProviderImpl(api, null, null, dataLogger);
+	}
+
+	/**
+	 * Creating a KeyProviderImpl based on private and public key files in PEM format. The keys must be RSA keys and
+	 * must match each other.
 	 *
 	 * @param api
 	 *            not <code>null</code>
@@ -56,11 +75,16 @@ public class KeyProviderImpl implements KeyProvider, InitializingBean
 	 *            not <code>null</code>
 	 * @param publicKeyFile
 	 *            not <code>null</code>
+	 * @param dataLogger
+	 *            not <code>null</code>
 	 * @return KeyProvider
 	 */
 	public static KeyProviderImpl fromFiles(ProcessPluginApi api, String privateKeyFile, String publicKeyFile,
 			DataLogger dataLogger)
 	{
+		Objects.requireNonNull(privateKeyFile, "privateKeyFile path must not be null");
+		Objects.requireNonNull(publicKeyFile, "publicKeyFile path must not be null");
+
 		logger.info("Configuring KeyProvider with private-key from '{}' and public-key from '{}'", privateKeyFile,
 				publicKeyFile);
 
@@ -69,14 +93,11 @@ public class KeyProviderImpl implements KeyProvider, InitializingBean
 
 		try
 		{
-			if (privateKeyFile != null)
-			{
-				Path privateKeyPath = Paths.get(privateKeyFile);
-				if (!Files.isReadable(privateKeyPath))
-					throw new RuntimeException("PrivateKey at '" + privateKeyFile + "' not readable");
+			Path privateKeyPath = Paths.get(privateKeyFile);
+			if (!Files.isReadable(privateKeyPath))
+				throw new RuntimeException("PrivateKey at '" + privateKeyFile + "' not readable");
 
-				privateKey = PemIo.readPrivateKeyFromPem(privateKeyPath);
-			}
+			privateKey = PemIo.readPrivateKeyFromPem(privateKeyPath);
 		}
 		catch (IOException | PKCSException e)
 		{
@@ -85,20 +106,29 @@ public class KeyProviderImpl implements KeyProvider, InitializingBean
 
 		try
 		{
-			if (publicKeyFile != null)
-			{
-				Path publicKeyPath = Paths.get(publicKeyFile);
-				if (!Files.isReadable(publicKeyPath))
-					throw new RuntimeException("PublicKey at '" + publicKeyFile + "' not readable");
+			Path publicKeyPath = Paths.get(publicKeyFile);
+			if (!Files.isReadable(publicKeyPath))
+				throw new RuntimeException("PublicKey at '" + publicKeyFile + "' not readable");
 
-				publicKey = PemIo.readPublicKeyFromPem(publicKeyPath);
-			}
+			publicKey = PemIo.readPublicKeyFromPem(publicKeyPath);
 		}
 		catch (NoSuchAlgorithmException | InvalidKeySpecException | IOException e)
 		{
 			throw new RuntimeException("Error while reading PublicKey from '" + publicKeyFile + "'", e);
 		}
 
+		if (privateKey == null || !(privateKey instanceof RSAPrivateKey))
+		{
+			throw new RuntimeException("PrivateKey '%s' is not an RSA based private key. Only RSA is supported."
+					.formatted(privateKeyFile));
+		}
+		if (publicKey == null || !((RSAPrivateKey) privateKey).getModulus().equals(publicKey.getModulus())
+				|| ((privateKey instanceof RSAPrivateCrtKey)
+						&& !((RSAPrivateCrtKey) privateKey).getPublicExponent().equals(publicKey.getPublicExponent())))
+		{
+			throw new RuntimeException(
+					"PrivateKey '%s' and PublicKey '%s' do not match.".formatted(privateKeyFile, publicKeyFile));
+		}
 		return new KeyProviderImpl(api, privateKey, publicKey, dataLogger);
 	}
 
@@ -144,7 +174,6 @@ public class KeyProviderImpl implements KeyProvider, InitializingBean
 					}
 					else
 						logger.info("Updating PublicKey Bundle on DSF FHIR server with baseUrl '{}' ...", baseUrl);
-
 				}
 				else
 					logger.info("Creating new PublicKey Bundle on DSF FHIR server with baseUrl '{}' ...", baseUrl);

--- a/src/test/java/de/medizininformatik_initiative/processes/common/crypto/KeyProviderImplTest.java
+++ b/src/test/java/de/medizininformatik_initiative/processes/common/crypto/KeyProviderImplTest.java
@@ -1,0 +1,127 @@
+package de.medizininformatik_initiative.processes.common.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Test;
+
+import de.rwh.utils.crypto.io.PemIo;
+
+public class KeyProviderImplTest
+{
+
+	@Test
+	public void errorOnPrivateAndPublicKeyFilesAreNull() throws Exception
+	{
+		assertThatThrownBy(() -> KeyProviderImpl.fromFiles(null, null, null, null))
+				.hasMessage("privateKeyFile path must not be null");
+	}
+
+	@Test
+	public void errorOnPrivateKeyFileIsNull() throws Exception
+	{
+		var generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(1024);
+		var nonMatchingPublicKey = (RSAPublicKey) generator.generateKeyPair().getPublic();
+		var publicKeyFile = File.createTempFile("publicKey", ".pem");
+		publicKeyFile.deleteOnExit();
+		PemIo.writePublicKeyToPem(nonMatchingPublicKey, publicKeyFile.toPath());
+
+		assertThatThrownBy(() -> KeyProviderImpl.fromFiles(null, null, publicKeyFile.getAbsolutePath(), null))
+				.hasMessage("privateKeyFile path must not be null");
+	}
+
+	@Test
+	public void errorOnPublicKeyFileIsNull() throws Exception
+	{
+		var generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(1024);
+		var privateKey = (RSAPrivateKey) generator.generateKeyPair().getPrivate();
+		var privateKeyFile = File.createTempFile("privateKey", ".pem");
+		privateKeyFile.deleteOnExit();
+		PemIo.writeNotEncryptedPrivateKeyToOpenSslClassicPem(new BouncyCastleProvider(), privateKeyFile.toPath(),
+				privateKey);
+
+		assertThatThrownBy(() -> KeyProviderImpl.fromFiles(null, privateKeyFile.getAbsolutePath(), null, null))
+				.hasMessage("publicKeyFile path must not be null");
+	}
+
+	@Test
+	public void errorOnNonMatchingPrivateAndPublicKey() throws Exception
+	{
+		var generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(1024);
+		var privateKey = (RSAPrivateKey) generator.generateKeyPair().getPrivate();
+		var nonMatchingPublicKey = (RSAPublicKey) generator.generateKeyPair().getPublic();
+		var privateKeyFile = File.createTempFile("privateKey", ".pem");
+		var publicKeyFile = File.createTempFile("publicKey", ".pem");
+		privateKeyFile.deleteOnExit();
+		publicKeyFile.deleteOnExit();
+		PemIo.writePublicKeyToPem(nonMatchingPublicKey, publicKeyFile.toPath());
+		PemIo.writeNotEncryptedPrivateKeyToOpenSslClassicPem(new BouncyCastleProvider(), privateKeyFile.toPath(),
+				privateKey);
+
+		assertThat(privateKey.getModulus()).describedAs("private and public keys do not match")
+				.isNotEqualByComparingTo(nonMatchingPublicKey.getModulus());
+		assertThatThrownBy(() -> KeyProviderImpl.fromFiles(null, privateKeyFile.getAbsolutePath(),
+				publicKeyFile.getAbsolutePath(), null))
+				.hasMessage("PrivateKey '%s' and PublicKey '%s' do not match."
+						.formatted(privateKeyFile.getAbsolutePath(), publicKeyFile.getAbsolutePath()));
+	}
+
+	@Test
+	public void errorOnNonRSAPrivateKey() throws Exception
+	{
+		var dsaGenerator = KeyPairGenerator.getInstance("DSA");
+		var rsaGenerator = KeyPairGenerator.getInstance("RSA");
+		dsaGenerator.initialize(512);
+		rsaGenerator.initialize(1024);
+		var privateKey = dsaGenerator.generateKeyPair().getPrivate();
+		var nonMatchingPublicKey = (RSAPublicKey) rsaGenerator.generateKeyPair().getPublic();
+		var privateKeyFile = File.createTempFile("privateKey", ".pem");
+		var publicKeyFile = File.createTempFile("publicKey", ".pem");
+		privateKeyFile.deleteOnExit();
+		publicKeyFile.deleteOnExit();
+		PemIo.writePublicKeyToPem(nonMatchingPublicKey, publicKeyFile.toPath());
+		PemIo.writeNotEncryptedPrivateKeyToOpenSslClassicPem(new BouncyCastleProvider(), privateKeyFile.toPath(),
+				privateKey);
+
+		assertThat(privateKey).isNotInstanceOf(RSAPrivateKey.class);
+		assertThatThrownBy(() -> KeyProviderImpl.fromFiles(null, privateKeyFile.getAbsolutePath(),
+				publicKeyFile.getAbsolutePath(), null))
+				.hasMessageContaining("is not an RSA based private key. Only RSA is supported.");
+	}
+
+	@Test
+	public void matchingPrivateAndPublicKey() throws Exception
+	{
+		var generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(1024);
+		var keyPair = generator.generateKeyPair();
+		var privateKey = (RSAPrivateKey) keyPair.getPrivate();
+		var matchingPublicKey = (RSAPublicKey) keyPair.getPublic();
+		var privateKeyFile = File.createTempFile("privateKey", ".pem");
+		var publicKeyFile = File.createTempFile("publicKey", ".pem");
+		privateKeyFile.deleteOnExit();
+		publicKeyFile.deleteOnExit();
+		PemIo.writePublicKeyToPem((RSAPublicKey) matchingPublicKey, publicKeyFile.toPath());
+		PemIo.writeNotEncryptedPrivateKeyToOpenSslClassicPem(new BouncyCastleProvider(), privateKeyFile.toPath(),
+				privateKey);
+
+		var provider = KeyProviderImpl.fromFiles(null, privateKeyFile.getAbsolutePath(),
+				publicKeyFile.getAbsolutePath(), null);
+
+		assertThat(((RSAPrivateKey) provider.getPrivateKey()).getModulus()).describedAs("same private key")
+				.isEqualByComparingTo(privateKey.getModulus());
+		assertThat(((RSAPublicKey) provider.getPublicKey()).getModulus()).describedAs("same public key")
+				.isEqualByComparingTo(matchingPublicKey.getModulus());
+		assertThat(((RSAPrivateKey) provider.getPrivateKey()).getModulus()).describedAs("private and public keys match")
+				.isEqualByComparingTo(((RSAPublicKey) provider.getPublicKey()).getModulus());
+	}
+}


### PR DESCRIPTION
Only allow RSA keys because the PemIo helper class currently just reads RSAPublicKeys from .pem files.